### PR TITLE
Integrate JaCoCo for improved test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,8 @@
 							<include>**/*Test</include>
 							<include>**/*Spec</include>
 						</includes>
-						<statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+						<statelessTestsetReporter
+							implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
 							<disable>false</disable>
 							<version>3.0</version>
 							<usePhrasedFileName>false</usePhrasedFileName>
@@ -190,6 +191,13 @@
 					<groupId>org.sonarsource.scanner.maven</groupId>
 					<artifactId>sonar-maven-plugin</artifactId>
 					<version>3.9.1.2184</version>
+				</plugin>
+
+				<!-- JaCoCo (Java Code Coverage Library) -->
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.11</version>
 				</plugin>
 
 				<!-- Spotless is a general-purpose formatting plugin -->
@@ -238,6 +246,29 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Added support for JaCoCo (Java Code Coverage Library) to the project, which is implemented in the 'pom.xml' file. This plugin will ensure a greater reach of test coverage for our code base, thereby boosting the product's overall quality. To utilize it, specific executions such as 'prepare-agent' and 'report' have been specified, with the report format set to XML.