### PR TITLE
Update card number validation rule

### DIFF
--- a/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/impl/CardNumberValidator.java
+++ b/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/impl/CardNumberValidator.java
@@ -17,8 +17,8 @@ public final class CardNumberValidator implements Predicate<String> {
 		if (cardNumber == null) {
 			return false;
 		}
-		var number = cardNumber.replaceAll(" ", "");
-		if (!number.matches("\\d{2,}")) {
+		var number = cardNumber.replace(" ", "");
+		if (!number.matches("\\d{2,19}")) {
 			return false;
 		}
 


### PR DESCRIPTION
Card number validation rule was modified to check that card numbers consist only of 2 to 19 digits. The change ensures that we accept only valid card numbers according to issuer standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved card number validation to allow for card numbers with 2 to 19 digits and ensure proper formatting by removing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->