### PR TITLE
Refactor bank card number generation and validation logic

### DIFF
--- a/jmp-bank-api/pom.xml
+++ b/jmp-bank-api/pom.xml
@@ -22,4 +22,12 @@
         </dependency>
     </dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+	
 </project>

--- a/jmp-cloud-bank-impl/pom.xml
+++ b/jmp-cloud-bank-impl/pom.xml
@@ -30,4 +30,12 @@
 		</dependency>
     </dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/BankImpl.java
+++ b/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/BankImpl.java
@@ -1,6 +1,7 @@
-package com.epam.engx.jmp.cloud.bank.impl;
+package com.epam.engx.jmp.cloud.bank;
 
 import com.epam.engx.jmp.api.Bank;
+import com.epam.engx.jmp.cloud.bank.cardnumber.CardNumberSupplier;
 import com.epam.engx.jmp.dto.BankCard;
 import com.epam.engx.jmp.dto.BankCardType;
 import com.epam.engx.jmp.dto.CreditBankCard;
@@ -9,14 +10,14 @@ import com.epam.engx.jmp.dto.User;
 
 import java.util.Objects;
 
-public final class BankCloudImpl implements Bank {
+public final class BankImpl implements Bank {
 
 	@Override
 	public BankCard createBankCard(User user, BankCardType type) {
 		Objects.requireNonNull(user, "User cannot be null");
 		Objects.requireNonNull(type, "Bank card type cannot be null");
 
-		var cardNumberSupplier = new LuhnCardNumberSupplier();
+		var cardNumberSupplier = new CardNumberSupplier();
 		var cardNumber = cardNumberSupplier.get();
 
 		return switch (type) {

--- a/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/cardnumber/CardNumberSupplier.java
+++ b/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/cardnumber/CardNumberSupplier.java
@@ -1,9 +1,10 @@
-package com.epam.engx.jmp.cloud.bank.impl;
+package com.epam.engx.jmp.cloud.bank.cardnumber;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import java.util.function.Supplier;
 
-public final class LuhnCardNumberSupplier implements CardNumberSupplier {
+public final class CardNumberSupplier implements Supplier<String> {
 	private static final int CARD_NUMBER_LENGTH = 16;
 	private static final Random RANDOM = new SecureRandom();
 
@@ -36,6 +37,6 @@ public final class LuhnCardNumberSupplier implements CardNumberSupplier {
 			alternate = !alternate;
 		}
 
-        return 10 - (sum % 10);
+		return 10 - (sum % 10);
 	}
 }

--- a/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/cardnumber/LuhnValidator.java
+++ b/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/cardnumber/LuhnValidator.java
@@ -1,6 +1,7 @@
-package com.epam.engx.jmp.cloud.bank.impl;
+package com.epam.engx.jmp.cloud.bank.cardnumber;
 
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * A class that provides Card Number validation functionality.
@@ -10,7 +11,8 @@ import java.util.function.Predicate;
  * The card number should not be null, consist of only digits (0-9), and follow the Luhn algorithm for validation.
  * </p>
  */
-public final class CardNumberValidator implements Predicate<String> {
+public final class LuhnValidator implements Predicate<String> {
+	private static final Predicate<String> CARD_NUMBER_VALIDATOR = Pattern.compile("\\d{2,19}").asPredicate();
 
 	@Override
 	public boolean test(String cardNumber) {
@@ -18,7 +20,7 @@ public final class CardNumberValidator implements Predicate<String> {
 			return false;
 		}
 		var number = cardNumber.replace(" ", "");
-		if (!number.matches("\\d{2,19}")) {
+		if (!CARD_NUMBER_VALIDATOR.test(number)) {
 			return false;
 		}
 

--- a/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/impl/CardNumberSupplier.java
+++ b/jmp-cloud-bank-impl/src/main/java/com/epam/engx/jmp/cloud/bank/impl/CardNumberSupplier.java
@@ -1,7 +1,0 @@
-package com.epam.engx.jmp.cloud.bank.impl;
-
-import java.util.function.Supplier;
-
-@FunctionalInterface
-public interface CardNumberSupplier extends Supplier<String> {
-}

--- a/jmp-cloud-bank-impl/src/main/java/module-info.java
+++ b/jmp-cloud-bank-impl/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 import com.epam.engx.jmp.api.Bank;
-import com.epam.engx.jmp.cloud.bank.impl.BankCloudImpl;
+import com.epam.engx.jmp.cloud.bank.BankImpl;
 
 module jmp.cloud.bank.impl {
 	requires transitive jmp.bank.api;
 	requires jmp.dto;
-	provides Bank with BankCloudImpl;
+	provides Bank with BankImpl;
 }

--- a/jmp-cloud-bank-impl/src/test/groovy/com/epam/engx/jmp/cloud/bank/BankImplSpec.groovy
+++ b/jmp-cloud-bank-impl/src/test/groovy/com/epam/engx/jmp/cloud/bank/BankImplSpec.groovy
@@ -1,4 +1,4 @@
-package com.epam.engx.jmp.cloud.bank.impl
+package com.epam.engx.jmp.cloud.bank
 
 
 import com.epam.engx.jmp.dto.BankCardType
@@ -10,10 +10,10 @@ import spock.lang.Subject
 
 import java.time.LocalDate
 
-class BankCloudImplSpec extends Specification {
+class BankImplSpec extends Specification {
 
 	@Subject
-	BankCloudImpl bankCloud = new BankCloudImpl()
+	BankImpl bankCloud = new BankImpl()
 
 	def "Test creating a credit bank card for a valid user"() {
 		given:

--- a/jmp-cloud-bank-impl/src/test/groovy/com/epam/engx/jmp/cloud/bank/cardnumber/CardNumberSupplierSpec.groovy
+++ b/jmp-cloud-bank-impl/src/test/groovy/com/epam/engx/jmp/cloud/bank/cardnumber/CardNumberSupplierSpec.groovy
@@ -1,13 +1,13 @@
-package com.epam.engx.jmp.cloud.bank.impl
+package com.epam.engx.jmp.cloud.bank.cardnumber
 
 
 import spock.lang.Specification
 
-class LuhnCardNumberSupplierSpec extends Specification {
+class CardNumberSupplierSpec extends Specification {
 
 	def "Generated card number should not be null"() {
 		given:
-		def cardNumberSupplier = new LuhnCardNumberSupplier()
+		def cardNumberSupplier = new CardNumberSupplier()
 
 		when:
 		def cardNumber = cardNumberSupplier.get()
@@ -18,7 +18,7 @@ class LuhnCardNumberSupplierSpec extends Specification {
 
 	def "Generated card number should have correct length"() {
 		given:
-		def cardNumberSupplier = new LuhnCardNumberSupplier()
+		def cardNumberSupplier = new CardNumberSupplier()
 
 		when:
 		def cardNumber = cardNumberSupplier.get()
@@ -29,8 +29,8 @@ class LuhnCardNumberSupplierSpec extends Specification {
 
 	def "Generated card number should pass Luhn algorithm check"() {
 		given:
-		def cardNumberSupplier = new LuhnCardNumberSupplier()
-		def luhnCheck = new CardNumberValidator()
+		def cardNumberSupplier = new CardNumberSupplier()
+		def luhnCheck = new LuhnValidator()
 
 		when:
 		def cardNumber = cardNumberSupplier.get()
@@ -41,7 +41,7 @@ class LuhnCardNumberSupplierSpec extends Specification {
 
 	def "Test calculateLuhnCheckDigit with card number #cardNumberWithoutCheckDigit and check digit #expectedCheckDigit"() {
 		given:
-		def luhnCardNumberSupplier = new LuhnCardNumberSupplier()
+		def luhnCardNumberSupplier = new CardNumberSupplier()
 
 		when:
 		def checkDigit = luhnCardNumberSupplier.calculateLuhnCheckDigit(cardNumberWithoutCheckDigit)

--- a/jmp-cloud-bank-impl/src/test/groovy/com/epam/engx/jmp/cloud/bank/cardnumber/LuhnValidatorSpec.groovy
+++ b/jmp-cloud-bank-impl/src/test/groovy/com/epam/engx/jmp/cloud/bank/cardnumber/LuhnValidatorSpec.groovy
@@ -1,12 +1,13 @@
-package com.epam.engx.jmp.cloud.bank.impl
+package com.epam.engx.jmp.cloud.bank.cardnumber
+
 
 import spock.lang.Specification
 
-class CardNumberValidatorSpec extends Specification {
+class LuhnValidatorSpec extends Specification {
 
 	def "Test with a known valid card number: #cardNumber"() {
 		given:
-		def luhnCheck = new CardNumberValidator()
+		def luhnCheck = new LuhnValidator()
 
 		when:
 		def isValid = luhnCheck.test(cardNumber)
@@ -26,7 +27,7 @@ class CardNumberValidatorSpec extends Specification {
 
 	def "Test with a known invalid card number: #cardNumber"() {
 		given:
-		def luhnCheck = new CardNumberValidator()
+		def luhnCheck = new LuhnValidator()
 
 		when:
 		def isValid = luhnCheck.test(cardNumber)
@@ -46,7 +47,7 @@ class CardNumberValidatorSpec extends Specification {
 
 	def "Test with a null card number"() {
 		given:
-		def luhnCheck = new CardNumberValidator()
+		def luhnCheck = new LuhnValidator()
 
 		when:
 		def isValid = luhnCheck.test(null)
@@ -57,7 +58,7 @@ class CardNumberValidatorSpec extends Specification {
 
 	def "Test with an empty card number"() {
 		given:
-		def luhnCheck = new CardNumberValidator()
+		def luhnCheck = new LuhnValidator()
 
 		when:
 		def isValid = luhnCheck.test("")
@@ -68,7 +69,7 @@ class CardNumberValidatorSpec extends Specification {
 
 	def "Test with a card number containing non-numeric characters"() {
 		given:
-		def luhnCheck = new CardNumberValidator()
+		def luhnCheck = new LuhnValidator()
 
 		when:
 		def isValid = luhnCheck.test("4532a15112830366")

--- a/jmp-cloud-service-impl/pom.xml
+++ b/jmp-cloud-service-impl/pom.xml
@@ -18,4 +18,12 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/jmp-dto/pom.xml
+++ b/jmp-dto/pom.xml
@@ -21,4 +21,13 @@
 			<artifactId>groovy</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
This commit includes a series of related changes aiming at improving the code organization and readability of the bank card-related logic in the jmp-cloud-bank-impl module. The primary changes are:

- The CardNumberSupplier and CardNumberValidator classes were renamed to CardNumberSupplier and LuhnValidator, respectively, to better reflect their roles.

- Their test classes were accordingly renamed to CardNumberSupplierSpec and LuhnValidatorSpec.

- The path of the CardNumberSupplier and LuhnValidator classes were changed to reside in the jmp.cloud.bank.cardnumber package for better organization.

- BankCloudImpl class was renamed to BankImpl to reflect that these changes are not necessarily cloud-specific. Its test class, BankCloudImplSpec also got renamed to BankImplSpec.

- Updates on pom.xml files to let maven-compiler-plugin collect information during the build and make the build more efficient.

All these refactorings are aimed to make the code cleaner and easy to navigate. Moreover, these changes have no effect on the functionality of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed and restructured packages and classes for clarity and better alignment with functionality.
  - Updated class implementations to adhere to interface contracts for card number generation and validation.

- **New Features**
  - Introduced a new card number format validator using regular expressions for enhanced validation.

- **Tests**
  - Updated test suites to reflect the refactoring of classes and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->