### PR TITLE
Add Maven Enforcer plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,9 @@
 
 		<plugins>
 			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,34 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.4.1</version>
+					<executions>
+						<execution>
+							<id>enforce-maven</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<requireMavenVersion>
+										<version>3.6.0</version>
+										<message>Apache Maven 3.6.0+ is required</message>
+									</requireMavenVersion>
+									<requireJavaVersion>
+										<version>11</version>
+										<message>Java Development Kit 11+ is required</message>
+									</requireJavaVersion>
+								</rules>
+								<fail>true</fail>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+
 				<!-- Maven Compiler Plugin -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The Maven Enforcer plugin is added to ensure project consistency across different environments. It mandates developers to use a minimum required version of Maven (3.6.0) and Java (11) for building the project. This step is important to avoid any build discrepancy due to the use of deprecated features in older versions.